### PR TITLE
Import .claude skills from skiploom

### DIFF
--- a/.claude/skills/branch-hygiene/SKILL.md
+++ b/.claude/skills/branch-hygiene/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: branch-hygiene
+description: Synchronize the local main branch with the remote. Use when a clean, up-to-date main is needed before creating a branch or merging.
+---
+
+Perform branch hygiene
+
+1. Use `git checkout main` to checkout `main`.
+2. Use `git fetch --prune` to fetch latest changes from the remote repository.
+3. Use `git pull` to update `main` with the latest changes.
+4. For each branch deleted from the remote repository:
+   a. Use `git branch -D {branch-name}` to delete the branch locally.

--- a/.claude/skills/create-adr/SKILL.md
+++ b/.claude/skills/create-adr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: create-adr
-description: Create a local Architecture Decision Records (ADR) file. Use when the asked to create an ADR.
+description: Create a local Architecture Decision Records (ADR) file. Use when asked to create an ADR.
 ---
 
 Create an ADR within a local ADR file (docs/adrs) around $ARGUMENTS.
 
-## ADR Template
+## Conventions
 
 ADRs use the filename format `ADR-{SCOPE}-{TOPIC}-{DATE}.md` where:
 
@@ -13,41 +13,7 @@ ADRs use the filename format `ADR-{SCOPE}-{TOPIC}-{DATE}.md` where:
 - `{TOPIC}`: The concern being addressed, not the solution chosen (e.g., `PERSISTENCE` not `POSTGRESQL`)
 - `{DATE}`: `YYYYMMDD`
 
-Use the following template:
-
-```markdown
-# ADR: {Title}
-
-## Status
-
-{Status}
-
-## Context
-
-What problem or need prompted this decision? Include constraints, requirements, and the alternatives evaluated.
-
-## Decision
-
-One-sentence statement of what was chosen.
-
-## Rationale
-
-Why this alternative was selected over others. Evaluate using three criteria, in order: impact, least astonishment, idiomaticity. Include a comparison table and "Why not X?" sections for each rejected alternative.
-
-## Consequences
-
-**Positive:**
-
-- Benefits of this decision.
-
-**Negative:**
-
-- Costs, risks, or tradeoffs accepted.
-
-**Neutral:**
-
-- Side effects that are neither positive nor negative.
-```
+See [TEMPLATE.md](TEMPLATE.md) for the ADR template.
 
 ADRs that include subsystem design decisions should add a **Design** section between Rationale and Consequences, with "Alternatives not chosen" noted inline for each subsystem decision.
 

--- a/.claude/skills/create-adr/TEMPLATE.md
+++ b/.claude/skills/create-adr/TEMPLATE.md
@@ -1,0 +1,31 @@
+# ADR: {Title}
+
+## Status
+
+{Status}
+
+## Context
+
+What problem or need prompted this decision? Include constraints, requirements, and the alternatives evaluated.
+
+## Decision
+
+One-sentence statement of what was chosen.
+
+## Rationale
+
+Why this alternative was selected over others. Evaluate using three criteria, in order: impact, least astonishment, idiomaticity. Include a comparison table and "Why not X?" sections for each rejected alternative.
+
+## Consequences
+
+**Positive:**
+
+- Benefits of this decision.
+
+**Negative:**
+
+- Costs, risks, or tradeoffs accepted.
+
+**Neutral:**
+
+- Side effects that are neither positive nor negative.

--- a/.claude/skills/create-eng-design/SKILL.md
+++ b/.claude/skills/create-eng-design/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: create-eng-design
+description: Create or update the engineering design document (docs/ENG-DESIGN.md). Use when engineering design changes need to be documented.
+---
+
+Create or update the engineering design document (`docs/ENG-DESIGN.md`) for $ARGUMENTS.
+
+## Before Modifying
+
+1. Read the existing `docs/ENG-DESIGN.md` to understand the current state of the document.
+2. Read relevant ADRs in `docs/adrs/` for architectural context behind existing sections.
+
+## Template
+
+See [TEMPLATE.md](TEMPLATE.md) for the engineering design document structure.
+
+## Workflow
+
+1. Identify which sections are affected by the change.
+2. Update affected sections to reflect the new or modified design.
+3. Add new sections following the template structure when introducing a new concern.
+4. Update the status table: set `Last Updated` to today's date.
+5. Update the Glossary if new domain terms are introduced.
+
+## Conventions
+
+- Sections document the current state of the system, not the history of changes.
+- Reference ADRs by relative link when a section's design is governed by an architectural decision (e.g., `(see [ADR-OP-PROBABILITY-CALCULATION-MULTISET-20260314](adrs/ADR-OP-PROBABILITY-CALCULATION-MULTISET-20260314.md))`).
+- Subsection decisions that chose one approach over others include an **Alternatives not chosen** block explaining what was rejected and why.
+- Keep the document self-contained: a reader should understand the system's design without consulting source code.

--- a/.claude/skills/create-eng-design/TEMPLATE.md
+++ b/.claude/skills/create-eng-design/TEMPLATE.md
@@ -1,0 +1,45 @@
+# Celebi Engineering Design
+
+| Status | Last Updated | Author |
+|--------|--------------|--------|
+| {Status} | {YYYY-MM-DD} | {Author} |
+
+## Overview
+
+High-level description of what the system is and what it does.
+
+### Glossary
+
+- **{Term}**: {Definition}
+
+## Architecture
+
+High-level architecture description and layer separation.
+
+```
+{Architecture diagram}
+```
+
+- **Presentation layer**: {Technology and role}
+- **Computation layer**: {Technology and role}
+
+## Key Components
+
+### {Component Name}
+
+Description of the component's responsibility, public API, and interactions.
+
+#### {Subcomponent or Detail}
+
+Specific implementation details, configuration, or behavior.
+
+## Environment
+
+- **Python**: {version}
+- **Dependencies**: {list or "None"}
+- **Run**: {command}
+- **Test**: {command}
+
+## Design Decisions
+
+Architectural decisions are recorded as ADRs in `docs/adrs/`. See the [ADR index](adrs/CLAUDE.md) for the full list and current status.

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -9,42 +9,20 @@ Create a GitHub Issue, using the GitHub (`gh`) CLI, about $ARGUMENTS
 
 1. **Determine milestone**: Determine the milestone and project from context.
    - If you were called from the `create-project` skill, then use that project.
-   - If you were called directly, then there is no milestone.
+   - If you were called from the `review-pr` skill, then use the milestone from the PR's related issue.
+   - If the issue reports a defect in an existing implementation, trace the defective code to its originating project:
+     1. Use `git blame` on the defective code to find the commit that introduced it.
+     2. Find the issue referenced in the commit message.
+     3. Use `gh issue view {issue} --json milestone` to get that issue's milestone.
+     4. If any step fails to produce a milestone, there is no milestone.
+   - Otherwise, there is no milestone.
 2. **Draft the issue** following the `## Issue Structure` and `## Style` guidelines below.
    a. **Validate acceptance criteria against ADRs**: Read the ADR index at `docs/adrs/CLAUDE.md` and identify any ADRs whose scope and topic are relevant to the issue's domain. For each relevant ADR with a status of "Accepted", read the ADR and verify that no acceptance criterion contradicts its decision or consequences. Revise any contradicting criteria to align with the ADR, noting the ADR reference in the criterion.
 3. **Create the issue**: `gh issue create --title "{title}" --body "{body}"` — include `--milestone "{title}"` if a milestone was selected in step 1.
 
-## Issue Structure:
+## Issue Structure
 
-```markdown
-## Project Reference
-
-[{project-title}]({project-file-location})
-
-## What is wrong?
-
-Clearly and concisely describe the problem including any details about how to observe the problem directly. Explain the impact the problem is having on the system and/or stakeholders. Quantifying with data where it is possible to reference this data. Describe any workarounds currently used to compensate for the issue.
-
-## Why is this a problem?
-
-Describe the root cause. Explain the technical reason the problem exists rather than simply repeating what is wrong. To make the issue actionable reference code areas and behaviors, not specific file paths or line numbers because those can change over time.
-
-## What is correct?
-
-Describe what the correct behavior of the system should be. Include design patterns, strategies, and objective best practices by name where relevant. Avoid being overly prescriptive because creating an implementation plan is the part working the issue (`work-issue`), not creating the issue (`create-issue`).
-
-## Edge cases (when applicable)
-
-Call out non-obvious or un-common scenarios to address. Explain what makes these scenarios non-obvious or un-common.
-
-## Acceptance criteria
-
-Checkboxes. Each one should be independently testable. Cover:
-
-- The happy path
-- Key edge cases
-- Things that should NOT change
-```
+See [TEMPLATE.md](TEMPLATE.md) for the issue structure template.
 
 ## Style
 

--- a/.claude/skills/create-issue/TEMPLATE.md
+++ b/.claude/skills/create-issue/TEMPLATE.md
@@ -1,0 +1,27 @@
+## Project Reference
+
+[{project-title}]({project-file-location})
+
+## What is wrong?
+
+Clearly and concisely describe the problem including any details about how to observe the problem directly. Explain the impact the problem is having on the system and/or stakeholders. Quantify with data where possible. Describe any workarounds currently used to compensate for the issue.
+
+## Why is this a problem?
+
+Describe the root cause. Explain the technical reason the problem exists rather than simply repeating what is wrong. To make the issue actionable reference code areas and behaviors, not specific file paths or line numbers because those can change over time.
+
+## What is correct?
+
+Describe what the correct behavior of the system should be. Include design patterns, strategies, and objective best practices by name where relevant. Avoid being overly prescriptive because creating an implementation plan is part of working the issue (`work-issue`), not creating the issue (`create-issue`).
+
+## Edge cases (when applicable)
+
+Call out non-obvious or un-common scenarios to address. Explain what makes these scenarios non-obvious or un-common.
+
+## Acceptance criteria
+
+Checkboxes. Each one should be independently testable. Cover:
+
+- The happy path
+- Key edge cases
+- Things that should NOT change

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -36,6 +36,8 @@ Create a GitHub pull request, using the GitHub (`gh`) CLI.
 
 ## Create the Pull Request
 
+Follow the structure in [`TEMPLATE.md`](TEMPLATE.md):
+
 1. Identify the issue.
 2. Describe how the changes address the issue.
 3. Describe how correctness was verified.

--- a/.claude/skills/create-pr/TEMPLATE.md
+++ b/.claude/skills/create-pr/TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+
+- {Description of what was changed and why.}
+
+Closes #{issue}
+
+## Correctness Verification
+
+- {How correctness was verified (tests, manual verification, etc.).}

--- a/.claude/skills/create-project/SKILL.md
+++ b/.claude/skills/create-project/SKILL.md
@@ -10,8 +10,8 @@ Create project within a local project file (docs/projects) around $ARGUMENTS.
 1. Create a GitHub issue to represent project creation.
 2. Create a working branch to use with the project creation GitHub issue.
 3. Create a GitHub Milestone matching the project title using `gh api repos/{owner}/{repo}/milestones -f title="V{VERSION} {Initiative Name}"`
-   * The milestone title must match the project title exactly (e.g., `V0.7 Project Workflow`).
-4. Create the project file at `docs/projects/V{VERSION}-{INITIATIVE}.md` using the template in `docs/projects/TEMPLATE.md`.
+   * The milestone title must match the project title exactly (e.g., `V1.02 Dark Mode and Dice Roller`).
+4. Create the project file at `docs/projects/V{VERSION}-{INITIATIVE}.md` using the template in [`TEMPLATE.md`](TEMPLATE.md).
    * Populate template sections from the confirmed research brief.
    * Populate the `### Design References` section from the collected design references.
    * Include the milestone URL in the `## References` section.

--- a/.claude/skills/create-project/TEMPLATE.md
+++ b/.claude/skills/create-project/TEMPLATE.md
@@ -1,0 +1,85 @@
+# {Version} {Initiative Name}
+
+| Status | Set On |
+|--------|--------|
+| {Status} | {YYYY-MM-DD} |
+
+## Context
+
+### Situation
+
+What is the current state?
+
+### Opportunity
+
+What's wrong with it, or what could be better?
+
+### Approach
+
+What can we do about it?
+
+#### Alternatives not chosen (optional)
+
+- **{Alternative}** — Why it was not chosen.
+
+#### Decisions (optional)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| {Decision} | {Choice} | {Rationale} |
+
+## Goals
+
+- What this project achieves.
+
+## Non-Goals
+
+- What this project explicitly does not attempt.
+
+## Exit Criteria
+
+- [ ] Verifiable conditions that define "done".
+
+For infrastructure or workflow projects, include at least one criterion that exercises the
+integrated system end-to-end (e.g., "Pipeline deploys to staging and serves traffic").
+Component-level criteria alone verify parts in isolation but not that the system functions
+as a whole.
+
+When a project introduces operational tooling (admin consoles, dashboards, management
+endpoints), include at least one criterion that exercises the tool end-to-end: navigate to
+it, authenticate, and perform the primary operation. Configuration-level checks (e.g.,
+"console accessible to authenticated users") are insufficient — they verify setup, not
+functionality.
+
+## Defects
+
+Defects identified during PR reviews that required resolution before merge.
+
+| PR | Finding | Resolution |
+|----|---------|------------|
+| [#{pr}]({url}) | {description} | {required resolution} |
+
+## Observations
+
+Observations identified during PR reviews for awareness or future improvement.
+
+| PR | Finding | Disposition |
+|----|---------|-------------|
+| [#{pr}]({url}) | {description} | {addressed / deferred to #{issue} / accepted} |
+
+## References
+
+- [{Version} {Initiative Name} Milestone](https://github.com/travisfrels/celebi/milestone/{number})
+- [#{issue} {Issue title}](https://github.com/travisfrels/celebi/issues/{number})
+
+### Follow-Up Issues
+
+- [#{issue} {Issue title}](https://github.com/travisfrels/celebi/issues/{number})
+
+### Pull Requests
+
+- [#{pr} {PR title}](https://github.com/travisfrels/celebi/pull/{number})
+
+### Design References
+
+- [{Article title}]({url})

--- a/.claude/skills/finish-issue/SKILL.md
+++ b/.claude/skills/finish-issue/SKILL.md
@@ -7,19 +7,13 @@ Finish GitHub issue $ARGUMENTS
 
 1. Use the `git` CLI to add, commit, and push any remaining changes to the working branch.
 2. Use `git log -n 10 --pretty=format:"%h - %an, %ar : %s"` to sanity check repository changes.
-3. Think critically about issue implementation and use `gh issue comment $ARGUMENTS --body '{Body}'` to post an implementation summary comment to the issue with the following sections:
-    - **What was implemented.**
-    - **Design decisions**: decisions made and the rationale behind them.
-    - **Open questions**: unresolved issues that remain.
-    - **Blockers**: what slowed or stopped progress, and what systemic condition caused it. None if unobstructed.
-    - **Rework**: what had to be redone and why. None if not applicable.
-    - **Scope changes**: what was added, dropped, or deferred from the original plan. None if unchanged.
+3. Think critically about issue implementation and use `gh issue comment $ARGUMENTS --body '{Body}'` to post an implementation summary comment to the issue. Follow the structure in [`work-issue/IMPLEMENTATION-SUMMARY-TEMPLATE.md`](../work-issue/IMPLEMENTATION-SUMMARY-TEMPLATE.md).
 4. Check for stale CLAUDE.md files.
 5. Create a GitHub pull request using the GitHub (`gh`) CLI:
     1. Verify prerequisites: on a working branch, working tree is clean.
     2. Gather context: find the base branch, view the diffs (`git diff {base}...HEAD`), find the related issue.
     3. Analyze: do the changes address the issue? Do the commits follow the implementation plan? Was correctness verified?
-    4. Create the PR:
+    4. Create the PR following the structure in [`create-pr/TEMPLATE.md`](../create-pr/TEMPLATE.md):
        - Identify the issue.
        - Describe how the changes address the issue.
        - Describe how correctness was verified.

--- a/.claude/skills/merge-main/SKILL.md
+++ b/.claude/skills/merge-main/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: merge-main
+description: Merge the latest main into the current working branch. Use when upstream changes need to be incorporated mid-flight.
+---
+
+Merge the latest main into the current working branch
+
+1. Record the current branch name.
+2. Perform branch hygiene using the `branch-hygiene` skill.
+3. Use `git checkout {recorded-branch}` to return to the original working branch.
+4. Use `git merge main` to merge main into the working branch.

--- a/.claude/skills/nope/SKILL.md
+++ b/.claude/skills/nope/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: nope
+description: Correction for prohibited behaviors. Use when Claude violates command style rules (compound commands, git -C flag).
+---
+
+Stop. A prohibited behavior was just performed. Acknowledge the violation, then review and internalize the rules below.
+
+## Prohibited Behaviors
+
+### 1. Compound commands are strictly prohibited
+
+Every shell command must be issued as its own, separate Bash tool call. Do not chain commands with `&&`, `||`, `;`, or any other operator.
+
+**Why:** The `settings.local.json` file defines permission patterns that are evaluated per Bash tool call. Compound commands cannot be matched against these patterns, which forces manual approval prompts and breaks the automated workflow.
+
+### 2. The git `-C` flag is prohibited
+
+Do not use `git -C {path}`. Instead, `cd` to the target directory as a separate Bash tool call, then run the git command.
+
+**Why:** `-C` is a form of compound command indirection — it changes the working directory inline, bypassing the same permission evaluation that compound commands bypass.
+
+## Correction
+
+1. Identify which rule was just violated.
+2. State what was done incorrectly.
+3. Redo the last action correctly, issuing each command as a separate Bash tool call.

--- a/.claude/skills/plan-project/SKILL.md
+++ b/.claude/skills/plan-project/SKILL.md
@@ -5,20 +5,21 @@ description: Plan a project by investigating the problem space, drafting project
 
 Plan a project around $ARGUMENTS
 
-1. Run the test suite to establish a clean baseline: `python -m pytest tests/ -v`. All tests must pass before proceeding. If any tests fail, report the failures to the user and stop — do not continue with project planning until the baseline is clean.
-2. Read `docs/ENG-DESIGN.md`, `docs/projects/CLAUDE.md`, and `docs/projects/TEMPLATE.md`.
-3. Read project documents in `docs/projects/` noting the status of the project to identify lessons learned and in-flight work.
-4. Examine the codebase for relevant files and documentation noting the behavior and constraints that each file imposes on the solution.
+1. Perform branch hygiene using the `branch-hygiene` skill.
+2. Run the test suite to establish a clean baseline: `python -m pytest tests/ -v`. All tests must pass before proceeding. If any tests fail, report the failures to the user and stop — do not continue with project planning until the baseline is clean.
+3. Read `docs/ENG-DESIGN.md`, `docs/projects/CLAUDE.md`, and [`create-project/TEMPLATE.md`](../create-project/TEMPLATE.md).
+4. Read project documents in `docs/projects/` noting the status of the project to identify lessons learned and in-flight work.
+5. Examine the codebase for relevant files and documentation noting the behavior and constraints that each file imposes on the solution.
   - Stop when you can describe the current state in the Situation section without gaps.
-5. Where the implementation space is non-obvious, consult official documentation and collect design reference URLs.
-6. Present a requirements summary to the user for confirmation before drafting the research brief:
+6. Where the implementation space is non-obvious, consult official documentation and collect design reference URLs.
+7. Present a requirements summary to the user for confirmation before drafting the research brief:
    * **Interpreted Intent**: A plain-language statement of what the project will build and the problem it solves.
    * **Key Assumptions**: Assumptions made that were not explicitly stated by the user.
    * **Scope Boundaries**: What is in scope and what is explicitly out of scope.
    * **Open Questions**: Ambiguities that need user input to resolve.
 
    Do not proceed to the research brief until the user confirms the requirements or provides corrections. Incorporate any corrections before continuing.
-7. Draft a research brief and present it to the user for confirmation:
+8. Draft a research brief and present it to the user for confirmation:
    * **Situation**: Current state, grounded in specific files, systems, and behaviors observed.
    * **Opportunity**: What is wrong or could be better, with root cause if applicable.
    * **Approach**: Generate viable alternatives — for each, describe what it is, how it addresses the problem, and its trade-offs. Present alternatives as columns in a markdown table with impact, least astonishment, and idiomaticity as rows at minimum. Then assess alternatives: score each against impact, least astonishment, and idiomaticity (High/Medium/Low), identify the most viable, and justify rejected alternatives. Present the recommendation with a decisions table if multiple decisions are involved.
@@ -27,11 +28,6 @@ Plan a project around $ARGUMENTS
    * **Exit Criteria**: Verifiable conditions that define "done." For infrastructure or workflow projects, include at least one criterion that exercises the integrated system end-to-end.
    * **Issue Decomposition**: Break exit criteria into discrete, implementable issues. Each issue should have a title and a brief description of its scope. For features that affect user-facing behavior, include E2E test criteria in the feature issue's acceptance criteria rather than deferring E2E coverage to a separate terminal issue.
    * **Design References**: External documentation URLs consulted during research.
-8. Iterate on user feedback until the research brief is confirmed.
-9. Evaluate each decision in the Approach section against the ADR eligibility criteria in `docs/adrs/CLAUDE.md`. For decisions that meet the criteria, create the ADR in `docs/adrs/` following the ADR template and conventions in `docs/adrs/CLAUDE.md`. Link the ADR in the research brief's Design References.
-10. Create the project definition file and GitHub Milestone from the confirmed research brief:
-    1. Create a GitHub issue to represent project creation.
-    2. Create a working branch to use with the project creation GitHub issue.
-    3. Create a GitHub Milestone matching the project title using `gh api repos/{owner}/{repo}/milestones -f title="V{VERSION} {Initiative Name}"`. The milestone title must match the project title exactly.
-    4. Create the project file at `docs/projects/V{VERSION}-{INITIATIVE}.md` using the template in `docs/projects/TEMPLATE.md`. Populate template sections from the confirmed research brief. Populate the `### Design References` section from the collected design references. Include the milestone URL in the `## References` section.
-    5. Create the GitHub issues for the project, each with `--milestone "{milestone title}"`. Follow the issue structure and style conventions in the `create-issue` skill definition.
+9. Iterate on user feedback until the research brief is confirmed.
+10. Evaluate each decision in the Approach section against the ADR eligibility criteria in `docs/adrs/CLAUDE.md`. For decisions that meet the criteria, create the ADR in `docs/adrs/` following the ADR template and conventions in `docs/adrs/CLAUDE.md`. Link the ADR in the research brief's Design References.
+11. Use the `create-project` skill to create the project definition file and GitHub Milestone from the confirmed research brief.

--- a/.claude/skills/project-post-mortem/SKILL.md
+++ b/.claude/skills/project-post-mortem/SKILL.md
@@ -39,11 +39,10 @@ Analyze the gathered context and participant input together. Artifact analysis a
 
 ## 3. Finish the Post-Mortem
 
-1. **Create a GitHub Issue**, to represent the project post-mortem.
+1. **Create a GitHub Issue** to represent the project post-mortem.
    - Assign the issue using `gh issue edit {issue-id} --add-assignee @me`.
-   - Checkout a working branch from `main` using:
-      a. `git checkout main`
-      b. `git checkout -b issue-{issue-id}-{slugified_issue_title}`
+   - Perform branch hygiene using the `branch-hygiene` skill.
+   - Checkout a working branch using `git checkout -b issue-{issue-id}-{slugified_issue_title}`.
 2. **Create GitHub Issues** for each identified opportunity, ordered descending by priority:
    - **Title**: `[Post-Mortem] {opportunity summary}`
    - **Body**: contributing factors, category, priority (High / Medium / Low), and recommended action.
@@ -56,40 +55,4 @@ Analyze the gathered context and participant input together. Artifact analysis a
 
 ## Post-Mortem Template
 
-```markdown
-## Post-Mortem
-
-{Overall assessment of the project.}
-
-### Timeline
-
-| When | Event |
-|------|-------|
-| {milestone or relative time} | {decision, blocker, or pivot} |
-
-### Impact
-
-{Cycle time per issue, PR cycle time, PR review iteration count, scope changes, milestone duration. Note: cycle time is elapsed time, not active work time. State explicitly where metrics were unavailable.}
-
-### What Went Well
-
-- {What succeeded and why — focus on process and systemic conditions.}
-
-### What Went Wrong
-
-{What failed and why — focus on process and systemic conditions, not individuals.}
-
-| Issue | Contributing Factors | Category |
-|-------|---------------------|----------|
-| {Issue} | {Contributing Factors} | {Category} |
-
-### Recommendations
-
-Actionable improvements for future projects, highest priority first.
-
-| Priority | Recommendation | Issue |
-|----------|---------------|-------|
-| High | {action} | {link} |
-| Medium | {action} | {link} |
-| Low | {action} | {link} |
-```
+See [TEMPLATE.md](TEMPLATE.md) for the post-mortem template.

--- a/.claude/skills/project-post-mortem/TEMPLATE.md
+++ b/.claude/skills/project-post-mortem/TEMPLATE.md
@@ -1,0 +1,35 @@
+## Post-Mortem
+
+{Overall assessment of the project.}
+
+### Timeline
+
+| When | Event |
+|------|-------|
+| {milestone or relative time} | {decision, blocker, or pivot} |
+
+### Impact
+
+{Cycle time per issue, PR cycle time, PR review iteration count, scope changes, milestone duration. Note: cycle time is elapsed time, not active work time. State explicitly where metrics were unavailable.}
+
+### What Went Well
+
+- {What succeeded and why — focus on process and systemic conditions.}
+
+### What Went Wrong
+
+{What failed and why — focus on process and systemic conditions, not individuals.}
+
+| Issue | Contributing Factors | Category |
+|-------|---------------------|----------|
+| {Issue} | {Contributing Factors} | {Category} |
+
+### Recommendations
+
+Actionable improvements for future projects, highest priority first.
+
+| Priority | Recommendation | Issue |
+|----------|---------------|-------|
+| High | {action} | {link} |
+| Medium | {action} | {link} |
+| Low | {action} | {link} |

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -53,8 +53,44 @@ Label each finding before posting:
 - **Defect** — Must be resolved before merge. Incorrect behavior, security issue, or a clear violation of project standards.
 - **Observation** — Does not block merge. Worth noting for awareness or future improvement.
 
+## Validate Findings
+
+Apply the [`/critique`](../critique/SKILL.md) skill to each finding before posting. The critique's verdict determines the finding's fate:
+
+- **Defects**: Confirmed Defect, Downgrade to Observation, or Dismiss.
+- **Observations**: Confirmed Observation or Dismiss.
+
+Validation reasoning is internal. Only confirmed findings and their verdicts appear in the posted review.
+
 ## Post the Pull Request Review
+
+Post only confirmed findings. Include the classification label (Defect or Observation) and the validation verdict for each finding so the PR author understands the reasoning.
 
 ```bash
 gh pr review $ARGUMENTS --comment --body '{Body}'
 ```
+
+If the review contains any confirmed defects, end the body with a **Merge Blocked** notice stating that defects must be resolved before merge.
+
+## Record Findings in Project Document
+
+After posting the review, record all confirmed findings in the associated project document in `docs/projects/`.
+
+1. Identify the project doc from the PR's related issue and its milestone. If the related issue has no milestone, skip this section.
+2. Add a row to the `## Defects` table for each confirmed defect: the PR, finding description, and required resolution.
+3. Add a row to the `## Observations` table for each confirmed observation: the PR, finding description, and disposition.
+4. Commit and push the project doc update.
+
+## Create Issues for Out-of-Scope Findings
+
+For each confirmed finding that should not be addressed in this PR, create a GitHub issue using the [`/create-issue`](../create-issue/SKILL.md) skill. Assign the issue to the same milestone as the PR's related issue so the finding is associated with the project whose implementation produced it.
+
+## Defect Deferral
+
+Defects must be resolved before merge. The PR author fixes the defects and the reviewer confirms resolution in a follow-up review.
+
+If deferral is necessary, the reviewer must post a comment to the PR documenting:
+
+1. The decision to defer the defect.
+2. The justification for deferral.
+3. Confirmation that the defect is tracked (in the project Defects table and/or as a follow-up issue).

--- a/.claude/skills/work-issue/IMPLEMENTATION-PLAN-TEMPLATE.md
+++ b/.claude/skills/work-issue/IMPLEMENTATION-PLAN-TEMPLATE.md
@@ -1,0 +1,6 @@
+## Implementation Plan
+
+1. **{Step title}** — {Description of what this step does and why.}
+   - File: `{path/to/file}`
+2. **{Step title}** — {Description of what this step does and why.}
+   - File: `{path/to/file}`

--- a/.claude/skills/work-issue/IMPLEMENTATION-SUMMARY-TEMPLATE.md
+++ b/.claude/skills/work-issue/IMPLEMENTATION-SUMMARY-TEMPLATE.md
@@ -1,0 +1,25 @@
+## Implementation Summary
+
+### What was implemented
+
+- {Description of what was built or changed.}
+
+### Design decisions
+
+- **{Decision}** — {Rationale behind the decision.}
+
+### Open questions
+
+- {Unresolved issues that remain. None if all questions resolved.}
+
+### Blockers
+
+- {What slowed or stopped progress, and what systemic condition caused it. None if unobstructed.}
+
+### Rework
+
+- {What had to be redone and why. None if not applicable.}
+
+### Scope changes
+
+- {What was added, dropped, or deferred from the original plan. None if unchanged.}

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -7,29 +7,25 @@ Implement the GitHub issue $ARGUMENTS
 
 ## 1. Branch Hygiene
 
-1. Use `git checkout main` to checkout `main`.
-2. Use `git fetch --prune` to fetch latest changes from the remote repository.
-3. Use `git pull` to update `main` with the latest changes.
-4. For each branch deleted from the remote repository:
-   a. Use `git branch -D {branch-name}` to delete the branch locally.
+Perform branch hygiene using the `branch-hygiene` skill.
 
 ## 2. Plan the Implementation
 
 1. Read `docs/ENG-DESIGN.md`.
-2. Read the issue using `gh issue view $ARGUMENTS && gh issue view $ARGUMENTS --comments`.
-3. Identify the key decision points for implementing issue $ARGUMENTS.
+2. Read the issue using `gh issue view $ARGUMENTS`.
+3. Read the issue comments using `gh issue view $ARGUMENTS --comments`.
+4. Identify the key decision points for implementing issue $ARGUMENTS.
   - A decision point is any choice between meaningfully different implementation approaches that affects design, behavior, or maintainability.
   - For each decision point:
     a. **Generate alternatives**: A viable alternative is one that is objectively reasonable and feasibly implementable within project constraints. Where the implementation space is non-obvious, consult official documentation and cite relevant excerpts. For each alternative, describe: what it is, how it addresses the problem, and its trade-offs. Present alternatives as columns in a markdown table. Use impact, least astonishment, and idiomaticity as rows at minimum; add other relevant trade-off dimensions as needed. Do not score, rank, or advocate. Characterize only.
     b. **Assess alternatives**: Score each alternative against impact (High/Medium/Low), least astonishment (High/Medium/Low), and idiomaticity (High/Medium/Low). Present scores in a markdown table with criteria as rows and alternatives as columns. Identify the most viable alternative and justify the selection. List alternatives not chosen and justify their rejection.
-    c. Present the analysis and recommendation to the user and get explicit confirmation before proceeding.
-    d. If the user rejects the recommendation, refine the alternatives and re-present.
-    e. After the user confirms the recommendation, evaluate the decision against the ADR eligibility criteria in `docs/adrs/CLAUDE.md`.
+    c. Present the analysis and selected approach. Proceed with the selected approach.
+    d. Evaluate the decision against the ADR eligibility criteria in `docs/adrs/CLAUDE.md`.
 
 ## 3. Implementation
 
 1. Assign the issue using `gh issue edit $ARGUMENTS --add-assignee @me`.
-2. Post a step-by-step implementation plan using `gh issue comment $ARGUMENTS --body '{Implementation_Plan}'`.
+2. Post a step-by-step implementation plan using `gh issue comment $ARGUMENTS --body '{Implementation_Plan}'`. Follow the structure in [`IMPLEMENTATION-PLAN-TEMPLATE.md`](IMPLEMENTATION-PLAN-TEMPLATE.md).
 3. Checkout a working branch from `main` using `git checkout -b issue-$ARGUMENTS-{slugified_issue_title}`.
 4. Push the branch to origin using `git push --set-upstream origin issue-$ARGUMENTS-{slugified_issue_title}`.
 5. For each decision that meets the criteria:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,14 @@ Custom skills are defined in `.claude/skills/`. Each skill has a `SKILL.md` with
 | `review-pr` | Review a GitHub pull request |
 | `fetch-pr` | Fetch PR details, comments, and reviews |
 | `create-adr` | Create an Architecture Decision Record |
+| `create-eng-design` | Create or update the engineering design document |
 | `design` | Generate solution alternatives (used with assess-alternatives) |
 | `assess-alternatives` | Score and select from alternatives |
 | `critique` | Critical assessment of a statement or idea |
 | `project-post-mortem` | Post-mortem analysis after project completion |
+| `branch-hygiene` | Synchronize local main with remote, prune stale branches |
+| `merge-main` | Merge latest main into current working branch |
+| `nope` | Correct prohibited behaviors (compound commands, git -C) |
 
 ## Conventions
 

--- a/docs/projects/V1.02-DARK-MODE-AND-DICE-ROLLER.md
+++ b/docs/projects/V1.02-DARK-MODE-AND-DICE-ROLLER.md
@@ -92,6 +92,8 @@ Three changes are required:
 
 ### Pull Requests
 
+- [#38 Import .claude skills from skiploom](https://github.com/travisfrels/celebi/pull/38)
+
 ### Design References
 
 - [Tkinter ttk.Style documentation](https://docs.python.org/3/library/tkinter.ttk.html#ttk-styling)

--- a/docs/projects/V1.02-DARK-MODE-AND-DICE-ROLLER.md
+++ b/docs/projects/V1.02-DARK-MODE-AND-DICE-ROLLER.md
@@ -3,6 +3,7 @@
 | Status | Set On |
 |--------|--------|
 | Planning | 2026-03-22 |
+| Active | 2026-03-22 |
 
 ## Context
 
@@ -25,7 +26,7 @@ Celebi (V1.01) is a zero-dependency Python/Tkinter desktop app with:
 
 Three changes are required:
 
-1. **Settings cleanup** — Replace celebi's `.claude/settings.local.json` with celebi-appropriate permissions modeled after skiploom's structure: keep common entries (git, gh, WebSearch, WebFetch for relevant domains) and replace project-specific entries (gradle -> pytest, docker/playwright -> python).
+1. **Import .claude skills from skiploom** — Import 4 missing skill directories, 8 missing template files, and update 9 divergent SKILL.md files to match skiploom. Adapt skiploom-specific content (test commands, tier references, project-specific paths) for celebi.
 
 2. **Dark mode via ttk.Style + winreg** — Detect the Windows system theme at startup using `winreg` (stdlib) and apply matching light/dark color palettes via `ttk.Style`. Maintains the zero-dependency constraint from ADR-OP-GUI-FRAMEWORK-20260313.
 
@@ -67,7 +68,9 @@ Three changes are required:
 
 ## Exit Criteria
 
-- [ ] `.claude/settings.local.json` contains only celebi-relevant permissions (python, pytest, git, gh) with no skiploom-specific entries (gradle, docker, playwright, npm)
+- [ ] All 4 missing skill directories imported from skiploom (branch-hygiene, create-eng-design, merge-main, nope)
+- [ ] All 8 missing template files imported from skiploom
+- [ ] All 9 divergent SKILL.md files updated to match skiploom, adapted for celebi
 - [ ] App detects Windows light/dark mode at startup and applies matching theme to all widgets
 - [ ] Light theme and dark theme are visually distinct with readable contrast for all widget types (labels, spinboxes, buttons, treeview, frames)
 - [ ] Each scenario has a "Roll" button that generates random dice using that scenario's pool size, selection strategy, pick count, and modifier
@@ -81,7 +84,7 @@ Three changes are required:
 
 - [V1.02 Dark Mode and Dice Roller Milestone](https://github.com/travisfrels/celebi/milestone/3)
 - [#32 Create V1.02 Dark Mode and Dice Roller project](https://github.com/travisfrels/celebi/issues/32)
-- [#33 Tailor .claude/settings.local.json for celebi](https://github.com/travisfrels/celebi/issues/33)
+- [#33 Import .claude skills from skiploom](https://github.com/travisfrels/celebi/issues/33)
 - [#34 Add OS-aware light/dark theme support](https://github.com/travisfrels/celebi/issues/34)
 - [#35 Add dice roller to ScenarioFrame](https://github.com/travisfrels/celebi/issues/35)
 


### PR DESCRIPTION
## Summary

- Import 4 missing skill directories from skiploom (branch-hygiene, create-eng-design, merge-main, nope)
- Import 8 missing template files (TEMPLATE.md for create-adr, create-issue, create-pr, create-project, create-eng-design, project-post-mortem; IMPLEMENTATION-PLAN-TEMPLATE.md and IMPLEMENTATION-SUMMARY-TEMPLATE.md for work-issue)
- Update 9 divergent SKILL.md files to match skiploom (create-adr, create-issue, create-pr, create-project, finish-issue, plan-project, project-post-mortem, review-pr, work-issue)
- Adapt skiploom-specific content for celebi: test commands, project paths, remove cross-tier checks, simplify create-eng-design template
- Update CLAUDE.md skill table with 4 new skills
- Set V1.02 project to Active, update issue #33 reference

Closes #33

## Correctness Verification

- All 93 existing tests pass (`python -m pytest tests/ -v`)
- Verified all 17 skill directories present in celebi match skiploom's 17
- Verified all template files present
- Confirmed skiploom-specific content adapted (test command, repo URLs, cross-tier check removed, eng-design template simplified)