### PR TITLE
Add OS-aware light/dark theme support

### DIFF
--- a/docs/ENG-DESIGN.md
+++ b/docs/ENG-DESIGN.md
@@ -51,6 +51,17 @@ Uses multiset enumeration with multinomial weighting to compute exact probabilit
 
 Enum (`TOP`, `BOTTOM`) controlling whether the highest or lowest dice from the pool are selected for the total.
 
+### theme
+
+OS-aware theming module (`src/theme.py`). Public API:
+
+| Function | Purpose |
+|----------|---------|
+| `detect_system_theme` | Read Windows `AppsUseLightTheme` registry value via `winreg`; fall back to LIGHT |
+| `apply_theme` | Configure `ttk.Style` (clam base) and root window background for a given `Theme` |
+
+Defines `Theme` enum (`LIGHT`, `DARK`) and light/dark color palettes. Called once at startup by `CelebiApp.__init__` before widget construction. Uses only stdlib (`winreg`, `tkinter.ttk`).
+
 ## Environment
 
 - **Python**: 3.10+

--- a/docs/projects/V1.02-DARK-MODE-AND-DICE-ROLLER.md
+++ b/docs/projects/V1.02-DARK-MODE-AND-DICE-ROLLER.md
@@ -93,6 +93,7 @@ Three changes are required:
 ### Pull Requests
 
 - [#38 Import .claude skills from skiploom](https://github.com/travisfrels/celebi/pull/38)
+- [#39 Add OS-aware light/dark theme support](https://github.com/travisfrels/celebi/pull/39)
 
 ### Design References
 

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -6,6 +6,7 @@ Application source code.
 
 - `app.py` — Tkinter GUI. `ScenarioFrame(ttk.Frame)` owns per-scenario state and widgets. `CelebiApp` orchestrates 1–4 `ScenarioFrame` instances with add/remove management.
 - `probability_engine.py` — Pure computation. No UI or I/O dependencies. Stdlib only (`itertools`, `math`, `collections`).
+- `theme.py` — OS-aware light/dark theming. Detects Windows system theme via `winreg`, applies palettes via `ttk.Style`. Stdlib only.
 
 ## Conventions
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import ttk
 
+from src.theme import apply_theme, detect_system_theme
 from src.probability_engine import (
     SelectionStrategy,
     calculate_probabilities,
@@ -246,6 +247,9 @@ class CelebiApp:
         self.root.title("Celebi \u2014 Trench Crusade Dice Probability Calculator")
         self.root.geometry("1200x600")
         self.root.minsize(400, 400)
+
+        theme = detect_system_theme()
+        apply_theme(self.root, theme)
 
         self.scenarios = []
         self._build_ui()

--- a/src/theme.py
+++ b/src/theme.py
@@ -1,0 +1,158 @@
+import enum
+import tkinter as tk
+from tkinter import ttk
+
+try:
+    import winreg
+except ImportError:
+    winreg = None
+
+_REGISTRY_PATH = r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize"
+_REGISTRY_KEY = "AppsUseLightTheme"
+
+
+class Theme(enum.Enum):
+    LIGHT = "light"
+    DARK = "dark"
+
+
+def detect_system_theme():
+    """Detect Windows light/dark mode from registry. Falls back to LIGHT."""
+    if winreg is None:
+        return Theme.LIGHT
+
+    try:
+        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, _REGISTRY_PATH)
+        value, _ = winreg.QueryValueEx(key, _REGISTRY_KEY)
+        winreg.CloseKey(key)
+        return Theme.DARK if value == 0 else Theme.LIGHT
+    except (OSError, FileNotFoundError):
+        return Theme.LIGHT
+
+
+_PALETTES = {
+    Theme.LIGHT: {
+        "bg": "#f0f0f0",
+        "fg": "#1a1a1a",
+        "field_bg": "#ffffff",
+        "field_fg": "#1a1a1a",
+        "select_bg": "#0078d4",
+        "select_fg": "#ffffff",
+        "button_bg": "#e1e1e1",
+        "button_fg": "#1a1a1a",
+        "heading_bg": "#d8d8d8",
+        "heading_fg": "#1a1a1a",
+        "border": "#a0a0a0",
+        "trough": "#c8c8c8",
+        "indicator": "#ffffff",
+    },
+    Theme.DARK: {
+        "bg": "#2d2d2d",
+        "fg": "#d4d4d4",
+        "field_bg": "#1e1e1e",
+        "field_fg": "#d4d4d4",
+        "select_bg": "#264f78",
+        "select_fg": "#ffffff",
+        "button_bg": "#3c3c3c",
+        "button_fg": "#d4d4d4",
+        "heading_bg": "#3c3c3c",
+        "heading_fg": "#d4d4d4",
+        "border": "#555555",
+        "trough": "#1e1e1e",
+        "indicator": "#2d2d2d",
+    },
+}
+
+
+def apply_theme(root, theme):
+    """Configure ttk.Style and root window background for the given theme."""
+    palette = _PALETTES[theme]
+    style = ttk.Style(root)
+    style.theme_use("clam")
+
+    root.configure(bg=palette["bg"])
+
+    style.configure("TFrame", background=palette["bg"])
+
+    style.configure(
+        "TLabelframe",
+        background=palette["bg"],
+        foreground=palette["fg"],
+        bordercolor=palette["border"],
+    )
+    style.configure(
+        "TLabelframe.Label",
+        background=palette["bg"],
+        foreground=palette["fg"],
+    )
+
+    style.configure(
+        "TLabel",
+        background=palette["bg"],
+        foreground=palette["fg"],
+    )
+
+    style.configure(
+        "TButton",
+        background=palette["button_bg"],
+        foreground=palette["button_fg"],
+        bordercolor=palette["border"],
+    )
+    style.map(
+        "TButton",
+        background=[("active", palette["select_bg"])],
+        foreground=[("active", palette["select_fg"])],
+    )
+
+    style.configure(
+        "TSpinbox",
+        fieldbackground=palette["field_bg"],
+        foreground=palette["field_fg"],
+        background=palette["button_bg"],
+        bordercolor=palette["border"],
+        arrowcolor=palette["fg"],
+        selectbackground=palette["select_bg"],
+        selectforeground=palette["select_fg"],
+    )
+
+    style.configure(
+        "TRadiobutton",
+        background=palette["bg"],
+        foreground=palette["fg"],
+        indicatorcolor=palette["indicator"],
+        indicatorbackground=palette["indicator"],
+    )
+    style.map(
+        "TRadiobutton",
+        background=[("active", palette["bg"])],
+        indicatorcolor=[("selected", palette["select_bg"])],
+    )
+
+    style.configure(
+        "Treeview",
+        background=palette["field_bg"],
+        foreground=palette["field_fg"],
+        fieldbackground=palette["field_bg"],
+        selectbackground=palette["select_bg"],
+        selectforeground=palette["select_fg"],
+        bordercolor=palette["border"],
+    )
+    style.configure(
+        "Treeview.Heading",
+        background=palette["heading_bg"],
+        foreground=palette["heading_fg"],
+        bordercolor=palette["border"],
+    )
+    style.map(
+        "Treeview.Heading",
+        background=[("active", palette["select_bg"])],
+        foreground=[("active", palette["select_fg"])],
+    )
+
+    style.configure(
+        "TScrollbar",
+        background=palette["button_bg"],
+        troughcolor=palette["trough"],
+        bordercolor=palette["border"],
+        arrowcolor=palette["fg"],
+    )

--- a/src/theme.py
+++ b/src/theme.py
@@ -1,5 +1,4 @@
 import enum
-import tkinter as tk
 from tkinter import ttk
 
 try:
@@ -22,10 +21,9 @@ def detect_system_theme():
         return Theme.LIGHT
 
     try:
-        key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, _REGISTRY_PATH)
-        value, _ = winreg.QueryValueEx(key, _REGISTRY_KEY)
-        winreg.CloseKey(key)
-        return Theme.DARK if value == 0 else Theme.LIGHT
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, _REGISTRY_PATH) as key:
+            value, _ = winreg.QueryValueEx(key, _REGISTRY_KEY)
+            return Theme.DARK if value == 0 else Theme.LIGHT
     except (OSError, FileNotFoundError):
         return Theme.LIGHT
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -6,6 +6,7 @@ Unit and integration tests. Run with `python -m pytest tests/ -v`.
 
 - `test_probability_engine.py` — Engine unit tests. Pure logic, no UI dependencies.
 - `test_app.py` — UI integration tests. Requires Tk; uses a withdrawn root window (`root.withdraw()`).
+- `test_theme.py` — Theme detection and application tests. Mocks `winreg` for detection; verifies `ttk.Style` configuration for all widget types.
 
 ## Conventions
 

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,168 @@
+import tkinter as tk
+from tkinter import ttk
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.theme import Theme, apply_theme, detect_system_theme
+
+_root = None
+
+
+def setUpModule():
+    global _root
+    _root = tk.Tk()
+    _root.withdraw()
+
+
+def tearDownModule():
+    global _root
+    _root.destroy()
+    _root = None
+
+
+class TestThemeEnum(unittest.TestCase):
+    def test_light_value(self):
+        self.assertEqual(Theme.LIGHT.value, "light")
+
+    def test_dark_value(self):
+        self.assertEqual(Theme.DARK.value, "dark")
+
+    def test_members(self):
+        self.assertEqual(set(Theme), {Theme.LIGHT, Theme.DARK})
+
+
+class TestDetectSystemTheme(unittest.TestCase):
+    @patch("src.theme.winreg")
+    def test_detects_dark_when_registry_returns_0(self, mock_winreg):
+        mock_key = MagicMock()
+        mock_winreg.OpenKey.return_value = mock_key
+        mock_winreg.QueryValueEx.return_value = (0, 1)
+        mock_winreg.HKEY_CURRENT_USER = 0x80000001
+
+        self.assertEqual(detect_system_theme(), Theme.DARK)
+        mock_winreg.CloseKey.assert_called_once_with(mock_key)
+
+    @patch("src.theme.winreg")
+    def test_detects_light_when_registry_returns_1(self, mock_winreg):
+        mock_key = MagicMock()
+        mock_winreg.OpenKey.return_value = mock_key
+        mock_winreg.QueryValueEx.return_value = (1, 1)
+        mock_winreg.HKEY_CURRENT_USER = 0x80000001
+
+        self.assertEqual(detect_system_theme(), Theme.LIGHT)
+        mock_winreg.CloseKey.assert_called_once_with(mock_key)
+
+    @patch("src.theme.winreg")
+    def test_falls_back_to_light_on_os_error(self, mock_winreg):
+        mock_winreg.OpenKey.side_effect = OSError("Registry not found")
+        mock_winreg.HKEY_CURRENT_USER = 0x80000001
+
+        self.assertEqual(detect_system_theme(), Theme.LIGHT)
+
+    @patch("src.theme.winreg")
+    def test_falls_back_to_light_on_file_not_found(self, mock_winreg):
+        mock_winreg.OpenKey.side_effect = FileNotFoundError("Key not found")
+        mock_winreg.HKEY_CURRENT_USER = 0x80000001
+
+        self.assertEqual(detect_system_theme(), Theme.LIGHT)
+
+
+class TestApplyTheme(unittest.TestCase):
+    def setUp(self):
+        self.root = _root
+        self.style = None
+
+    def tearDown(self):
+        for widget in self.root.winfo_children():
+            widget.destroy()
+        self.root.update()
+
+    def _apply(self, theme):
+        apply_theme(self.root, theme)
+        self.style = ttk.Style(self.root)
+
+    def test_light_sets_frame_background(self):
+        self._apply(Theme.LIGHT)
+        bg = self.style.lookup("TFrame", "background")
+        self.assertTrue(bg, "TFrame background should be set")
+
+    def test_dark_sets_frame_background(self):
+        self._apply(Theme.DARK)
+        bg = self.style.lookup("TFrame", "background")
+        self.assertTrue(bg, "TFrame background should be set")
+
+    def test_root_background_matches_palette(self):
+        self._apply(Theme.DARK)
+        root_bg = self.root.cget("bg")
+        frame_bg = self.style.lookup("TFrame", "background")
+        self.assertEqual(root_bg, frame_bg)
+
+    def test_all_widget_types_configured(self):
+        self._apply(Theme.DARK)
+        widget_types = [
+            "TFrame",
+            "TLabel",
+            "TButton",
+            "TSpinbox",
+            "TRadiobutton",
+            "Treeview",
+            "Treeview.Heading",
+            "TScrollbar",
+            "TLabelframe",
+            "TLabelframe.Label",
+        ]
+        for widget_type in widget_types:
+            with self.subTest(widget_type=widget_type):
+                bg = self.style.lookup(widget_type, "background")
+                self.assertTrue(bg, f"{widget_type} background should be set")
+
+    def test_dark_and_light_produce_different_colors(self):
+        apply_theme(self.root, Theme.LIGHT)
+        style = ttk.Style(self.root)
+        light_bg = style.lookup("TFrame", "background")
+
+        apply_theme(self.root, Theme.DARK)
+        dark_bg = style.lookup("TFrame", "background")
+
+        self.assertNotEqual(light_bg, dark_bg)
+
+    def test_treeview_heading_configured(self):
+        self._apply(Theme.DARK)
+        bg = self.style.lookup("Treeview.Heading", "background")
+        fg = self.style.lookup("Treeview.Heading", "foreground")
+        self.assertTrue(bg, "Treeview.Heading background should be set")
+        self.assertTrue(fg, "Treeview.Heading foreground should be set")
+
+
+class TestThemeIntegration(unittest.TestCase):
+    def setUp(self):
+        self.root = _root
+        self.app = None
+
+    def tearDown(self):
+        for widget in self.root.winfo_children():
+            widget.destroy()
+        self.root.update()
+
+    def test_app_has_theme_applied(self):
+        from src.app import CelebiApp
+
+        self.app = CelebiApp(root=self.root)
+        self.root.update()
+        style = ttk.Style(self.root)
+        bg = style.lookup("TFrame", "background")
+        self.assertTrue(bg, "Theme should be applied when CelebiApp is created")
+
+    def test_root_background_set_on_app_creation(self):
+        from src.app import CelebiApp
+
+        self.app = CelebiApp(root=self.root)
+        self.root.update()
+        root_bg = self.root.cget("bg")
+        style = ttk.Style(self.root)
+        frame_bg = style.lookup("TFrame", "background")
+        self.assertEqual(root_bg, frame_bg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -35,22 +35,22 @@ class TestDetectSystemTheme(unittest.TestCase):
     @patch("src.theme.winreg")
     def test_detects_dark_when_registry_returns_0(self, mock_winreg):
         mock_key = MagicMock()
-        mock_winreg.OpenKey.return_value = mock_key
+        mock_winreg.OpenKey.return_value.__enter__ = MagicMock(return_value=mock_key)
+        mock_winreg.OpenKey.return_value.__exit__ = MagicMock(return_value=False)
         mock_winreg.QueryValueEx.return_value = (0, 1)
         mock_winreg.HKEY_CURRENT_USER = 0x80000001
 
         self.assertEqual(detect_system_theme(), Theme.DARK)
-        mock_winreg.CloseKey.assert_called_once_with(mock_key)
 
     @patch("src.theme.winreg")
     def test_detects_light_when_registry_returns_1(self, mock_winreg):
         mock_key = MagicMock()
-        mock_winreg.OpenKey.return_value = mock_key
+        mock_winreg.OpenKey.return_value.__enter__ = MagicMock(return_value=mock_key)
+        mock_winreg.OpenKey.return_value.__exit__ = MagicMock(return_value=False)
         mock_winreg.QueryValueEx.return_value = (1, 1)
         mock_winreg.HKEY_CURRENT_USER = 0x80000001
 
         self.assertEqual(detect_system_theme(), Theme.LIGHT)
-        mock_winreg.CloseKey.assert_called_once_with(mock_key)
 
     @patch("src.theme.winreg")
     def test_falls_back_to_light_on_os_error(self, mock_winreg):
@@ -64,6 +64,10 @@ class TestDetectSystemTheme(unittest.TestCase):
         mock_winreg.OpenKey.side_effect = FileNotFoundError("Key not found")
         mock_winreg.HKEY_CURRENT_USER = 0x80000001
 
+        self.assertEqual(detect_system_theme(), Theme.LIGHT)
+
+    @patch("src.theme.winreg", None)
+    def test_falls_back_to_light_when_winreg_unavailable(self):
         self.assertEqual(detect_system_theme(), Theme.LIGHT)
 
 


### PR DESCRIPTION
## Summary

- Add `src/theme.py` module with `Theme` enum, `detect_system_theme()` (reads Windows registry via `winreg`), and `apply_theme()` (configures `ttk.Style` with clam base theme for all widget types).
- Light and dark color palettes with readable contrast for Frame, LabelFrame, Label, Button, Spinbox, Radiobutton, Treeview, Scrollbar.
- Integrate theme detection and application in `CelebiApp.__init__` before widget construction.
- 15 new tests covering enum, detection (mocked winreg), style application, and integration.
- Graceful fallback to light theme if registry read fails or on non-Windows platforms.

Closes #34

## Correctness Verification

- All 108 tests pass (93 existing + 15 new): `python -m pytest tests/ -v`
- Theme detection tests mock `winreg` to verify dark (registry=0), light (registry=1), and fallback (OSError, FileNotFoundError) paths.
- Style application tests verify all widget types are configured, root background matches palette, and dark/light produce distinct colors.
- Integration tests verify `CelebiApp` has theme applied on creation.